### PR TITLE
Fix FirebaseUser and userModel state mismatch issue on app launch (iOS).

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,11 @@ void main() async {
       child: MyApp(),
     ),
   );
+  
+  // DEBUG
+  // FirebaseAuth.instance.authStateChanges().listen((event) {
+  //   print('got user event $event');
+  // });
 }
 
 class MyApp extends ConsumerStatefulWidget {
@@ -52,17 +57,22 @@ class _MyAppState extends ConsumerState<MyApp> {
               routesBuilder: (context) {
                 if (data != null) {
                   getData(ref, data);
-                  if (userModel != null) {
-                    return loggedInRoute;
-                  }
+                  return loggedInRoute;
                 }
                 return loggedOutRoute;
               },
             ),
             routeInformationParser: const RoutemasterParser(),
           ),
-          error: (error, stackTrace) => ErrorText(error: error.toString()),
-          loading: () => const Loader(),
-        );
+          error: (error, stackTrace) => Material(
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: ErrorText(
+                error: error.toString(),
+              ),
+            ),
+          ),
+          loading: () => const Material(child: Loader()),
+    );
   }
 }


### PR DESCRIPTION
Using current firebase package versions, if you stopped the app while you were logged in, you would end up with a null userModel but active user session on firebase, breaking the app flow.

The problem was on line 55 - you don't need to check for userModel.
I also added a bit of cleanup for error and loading states.

Tested on:

firebase_core: ^2.10.0
cloud_firestore: ^4.5.3
firebase_auth: ^4.4.2