### PR TITLE
Updated the checking user data condition to work state persistence fine

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,7 +52,7 @@ class _MyAppState extends ConsumerState<MyApp> {
               routesBuilder: (context) {
                 if (data != null) {
                   getData(ref, data);
-                  if (userModel != null) {
+                  if (ref.watch(userProvider) != null) {
                     return loggedInRoute;
                   }
                 }


### PR DESCRIPTION
Updated the Condition 

`                  if (ref.watch(userProvider) != null) {
                      return loggedInRoute;
                    }`
before is we are just checking if userModel is null or not but that is not working as we are not updating the state of userModel in getData function.

In the updated condition we arer directly checking the userProvider since it is updeted in the getData function and the state persistence will work